### PR TITLE
Track previous input state for accurate up/down/hold detection

### DIFF
--- a/Source/SDLInputHandler.h
+++ b/Source/SDLInputHandler.h
@@ -2,6 +2,7 @@
 #include <SDL3/SDL.h>
 #include <Tbx/Events/AppEvents.h>
 #include <Tbx/PluginAPI/RegisterPlugin.h>
+#include <array>
 #include <unordered_map>
 
 namespace SDLInput
@@ -32,6 +33,15 @@ namespace SDLInput
     
     private:
         std::unordered_map<int, SDL_Gamepad*> _gamepads = {};
+
+        std::array<Uint8, SDL_NUM_SCANCODES> _currKeyState{};
+        std::array<Uint8, SDL_NUM_SCANCODES> _prevKeyState{};
+
+        Uint32 _currMouseState = 0;
+        Uint32 _prevMouseState = 0;
+
+        std::unordered_map<int, std::array<Uint8, SDL_GAMEPAD_BUTTON_MAX>> _currGamepadBtnState;
+        std::unordered_map<int, std::array<Uint8, SDL_GAMEPAD_BUTTON_MAX>> _prevGamepadBtnState;
     };
 
     TBX_REGISTER_PLUGIN(SDLInputHandler);


### PR DESCRIPTION
## Summary
- maintain previous keyboard, mouse, and gamepad states
- compute down, up, and held transitions using stored state

## Testing
- `premake5 gmake` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*
- `g++ -std=c++17 -c Source/SDLInputHandler.cpp -I Source -o /tmp/test.o` *(fails: SDL3/SDL.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af46cc960c832789bd8b45a3d80504